### PR TITLE
A small layout issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Once you have an IAM user created and have their access key and secret access ke
     ```
 
 
-##What the script does
+## What the script does
 
 These are the different steps taken by the script
 
@@ -84,7 +84,6 @@ These are the different steps taken by the script
 Sample initial output should look like
 
 ```ini
-
 jim$ bash ez2ec2.sh
 Checking if AWS CLI is installed
 Using AWS CLI found at /Users/jim/anaconda/bin/aws
@@ -146,5 +145,4 @@ Connect to the instance using:
 ssh -i ~/ez2ec2key.pem ubuntu@54.152.170.[hidden]
 
 jim$
-
 ```


### PR DESCRIPTION
looking at the source, it was supposed to be a heading (H2), but due to missing a whitespace after the hashes it's not displayed as heading. This PR just fixes that simple thing